### PR TITLE
mock away sql database, handle err on close db statement, rename function, flag report error

### DIFF
--- a/ci_test.go
+++ b/ci_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 	opts := ParseArgs()
 	opts.Build.Env["os"] = "osx"
 	var err error
-	DB, err = newCIDB(opts.Database.User, opts.Database.Password, opts.Database.DatabaseName)
+	DB, err = openCIDB(opts.Database.User, opts.Database.Password, opts.Database.DatabaseName)
 	checkNoErr(err)
 	defer DB.Close()
 	jobChan = make(chan int64)

--- a/ci_test.go
+++ b/ci_test.go
@@ -2,16 +2,15 @@ package main
 
 import (
 	"log"
-	"os"
 	"syscall"
 	"testing"
+
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var DB *CIDB
-var jobChan chan int64
-var builder *Builder
+var opts *Options
 
 const BuildCommand = `#!/bin/bash
 echo "Setting Environments"
@@ -41,6 +40,26 @@ func TestAddPushEvent(t *testing.T) {
 		Ref:      "refs/heads/refine_ci_server",
 		Head:     "929924c96f51e2614efcba584fe9cf3a8cb4ec04",
 	}
+
+	opts.Build.Env["os"] = "osx"
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		panic(err)
+	}
+	mock.ExpectPrepare("select new_push_event")
+	rows := sqlmock.NewRows([]string{"buildId"}).AddRow(0)
+	mock.ExpectQuery("select new_push_event").WillReturnRows(rows)
+	rows = sqlmock.NewRows([]string{"pe.head", "pe.ref", "pe.clone_url"}).AddRow(ev.CloneURL, ev.Ref, ev.Head)
+	mock.ExpectQuery("SELECT pe.head, pe.ref, pe.clone_url FROM PushEvents ").WillReturnRows(rows)
+
+	DB := &CIDB{db}
+	checkNoErr(err)
+	defer DB.Close()
+	jobChan := make(chan int64)
+	builder, err := newBuilder(jobChan, opts, DB, nil)
+	checkNoErr(err)
+
 	bid, err := DB.AddPushEvent(&ev)
 	assert.NoError(t, err)
 	getEv, err := DB.GetPushEventByBuildID(bid)
@@ -84,14 +103,5 @@ func TestAddPushEvent(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	opts := ParseArgs()
-	opts.Build.Env["os"] = "osx"
-	var err error
-	DB, err = openCIDB(opts.Database.User, opts.Database.Password, opts.Database.DatabaseName)
-	checkNoErr(err)
-	defer DB.Close()
-	jobChan = make(chan int64)
-	builder, err = newBuilder(jobChan, opts, DB, nil)
-	checkNoErr(err)
-	os.Exit(m.Run())
+	opts = ParseArgs()
 }

--- a/conf.go
+++ b/conf.go
@@ -136,15 +136,12 @@ func ParseArgs() (opts *Options) {
 	fn := flag.String("config", "", "Configuration File")
 	flag.Parse()
 
-	if *fn == "" {
-		flag.Usage()
-		os.Exit(1)
+	if *fn != "" {
+		opts = newOptions()
+		content, err := ioutil.ReadFile(*fn)
+		checkNoErr(err)
+		err = yaml.Unmarshal(content, opts)
+		checkNoErr(err)
 	}
-
-	opts = newOptions()
-	content, err := ioutil.ReadFile(*fn)
-	checkNoErr(err)
-	err = yaml.Unmarshal(content, opts)
-	checkNoErr(err)
 	return
 }

--- a/conf.go
+++ b/conf.go
@@ -133,12 +133,16 @@ func ParseArgs() (opts *Options) {
 		flag.PrintDefaults()
 	}
 
-	fn := flag.String("config", "ci.yaml", "Configuration File")
+	fn := flag.String("config", "", "Configuration File")
 	flag.Parse()
+
+	if *fn == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
 	opts = newOptions()
-	f, err := os.Open(*fn)
-	checkNoErr(err)
-	content, err := ioutil.ReadAll(f)
+	content, err := ioutil.ReadFile(*fn)
 	checkNoErr(err)
 	err = yaml.Unmarshal(content, opts)
 	checkNoErr(err)

--- a/github_api.go
+++ b/github_api.go
@@ -19,8 +19,6 @@ func newGithubAPI(opts *Options) *GithubAPI {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: opts.Github.Token})
 	tc := oauth2.NewClient(oauth2.NoContext, ts)
 	gh := github.NewClient(tc)
-	_, _, err := gh.Repositories.Get(opts.Github.Owner, opts.Github.Name)
-	checkNoErr(err)
 	return &GithubAPI{
 		opts:     &opts.Github,
 		cli:      gh,
@@ -38,6 +36,12 @@ const (
 	// GithubFailure github check status failure
 	GithubFailure = "failure"
 )
+
+// CheckRepo check if github repository is valid
+func (gh *GithubAPI) CheckRepo() error {
+	_, _, err := gh.cli.Repositories.Get(gh.opts.Owner, gh.opts.Name)
+	return err
+}
 
 // CreateStatus will a check status for version `sha`.
 func (gh *GithubAPI) CreateStatus(sha string, status string) error {

--- a/main.go
+++ b/main.go
@@ -5,10 +5,15 @@ import "log"
 func main() {
 	opts := ParseArgs()
 	github := newGithubAPI(opts)
-	db, err := newCIDB(opts.Database.User, opts.Database.Password, opts.Database.DatabaseName)
+	err := github.CheckRepo()
 	checkNoErr(err)
+
+	db, err := openCIDB(opts.Database.User, opts.Database.Password, opts.Database.DatabaseName)
+	checkNoErr(err)
+
 	buildChan := make(chan int64, 256)
 	go func() { checkNoErr(db.RecoverFromPreviousDown(buildChan)) }()
+
 	builder, err := newBuilder(buildChan, opts, db, github)
 	builder.Start()
 	defer builder.Close()

--- a/model.go
+++ b/model.go
@@ -28,8 +28,8 @@ func (ev *PushEvent) BranchName() string {
 	return ev.Ref[11:]
 }
 
-// Create a database.
-func newCIDB(username string, passwd string, database string) (db *CIDB, err error) {
+// openCIDB opens database.
+func openCIDB(username string, passwd string, database string) (db *CIDB, err error) {
 	sdb, err := sql.Open("postgres", fmt.Sprintf("postgres://%s:%s@localhost/%s?sslmode=disable",
 		username, passwd, database))
 	if err != nil {
@@ -54,8 +54,13 @@ func (db *CIDB) AddPushEvent(event *PushEvent) (buildID int64, err error) {
 	if err != nil {
 		return
 	}
-	defer addPushEventStmt.Close()
+
 	err = addPushEventStmt.QueryRow(event.Head, event.Ref, event.CloneURL).Scan(&buildID)
+	if err != nil {
+		return
+	}
+
+	err = addPushEventStmt.Close()
 	return
 }
 


### PR DESCRIPTION
This PR mainly mocks away sql database in test, since we want to run test without having a configured database running.
@reyoung 