### PR TITLE
simplify build code flow

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -99,6 +99,7 @@ set -e
 `,
 			PushEventCloneTpl: `
 set -x
+cd {{.BuildPath}}
 git clone --branch={{.BranchName}} --depth=50 {{.CloneURL}} repo
 cd repo
 git checkout -qf {{.Head}}
@@ -106,13 +107,13 @@ git checkout -qf {{.Head}}
 			ExecuteTpl: `
 set +x
 if [ -f {{.Filename}} ]; then
-	{{.Filename}}
+	source {{.Filename}}
 else
 	echo "{{.Filename}} not found, it seems the ci script is not configured."
 fi
 `,
 			CleanTpl: `#!/bin/bash
-rm -rf repo
+rm -rf {{.BuildPath}}/*
 `,
 			Filename: "./ci.sh",
 		},

--- a/http_server.go
+++ b/http_server.go
@@ -222,7 +222,7 @@ func (httpServ *HTTPServer) buildOutputHandler(res http.ResponseWriter, req *htt
 		Status  string
 		Outputs []CommandLineOutput
 	}{
-		Status:  status.String(),
+		Status:  string(status),
 		Outputs: output,
 	})
 	checkNoErr(err)

--- a/templates/index.gohtml
+++ b/templates/index.gohtml
@@ -16,7 +16,7 @@
                 {{if eq (len $branch.Versions) 0}}
                 There is no building in {{ $branch.Name }}
                 {{else}}
-                The building in {{ $branch.Name }} is {{ (index $branch.Versions 0).Status.String }}
+                The building in {{ $branch.Name }} is {{ (index $branch.Versions 0).Status }}
                 {{end}}
             </div>
             {{ if ne (len $branch.Versions) 0 }}
@@ -25,10 +25,10 @@
                 <a href="/status/{{ $ver.Sha }}">
                     <li class="list-group-item">
                         <!--TODO(yuyang): Complete whole enumerations, or just put this method into go-->
-                        {{ if eq $ver.Status 1}}
-                        <span class="label label-success">{{ $ver.Status.String }}</span>
-                        {{ else if eq $ver.Status 0 }}
-                        <span class="label label-primary">{{ $ver.Status.String }}</span>
+                        {{ if eq $ver.Status "success"}}
+                        <span class="label label-success">{{ $ver.Status }}</span>
+                        {{ else if eq $ver.Status "running" }}
+                        <span class="label label-primary">{{ $ver.Status }}</span>
                         {{ end }}
                         {{ $ver.Sha }}
                     </li>


### PR DESCRIPTION
@reyoung 对build flow进行了一些改变。主要是没用channel了。
改变的原因主要是我认为在目前的情况下，synchronous调用方法比较简单。go channel的调用方法因为加入了async元素（channel）反而导致可读性降低，行数增加。
这是我的看法，不一定对。欢迎讨论：）
