### PR TITLE
Send a random field in ajax get.

### DIFF
--- a/templates/builds.gohtml
+++ b/templates/builds.gohtml
@@ -44,6 +44,7 @@ $(function(){
             id: bid,
             start: lineId,
             end: -1,
+            time: $.now(),
         }, function(data) {
             for(var i in data.Outputs) {
                 var opt = data.Outputs[i]


### PR DESCRIPTION
修复一个之前的bug。 build页面会向后端一直请求最新的build数据。但是，如果我们每次发的request如果一样的话，浏览器会把http get请求缓存下来。就不能一直持续得到最新的编译输出了。